### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/scan-library/route.ts
+++ b/src/app/api/scan-library/route.ts
@@ -73,7 +73,8 @@ export async function GET(request: NextRequest) {
     if (isAbsolute(resolvedPath)) {
       canonicalResolved = await realpath(resolvedPath);
     } else {
-      canonicalResolved = await realpath(resolve(canonicalRoot, resolvedPath));
+      const basePath = canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/';
+      canonicalResolved = await realpath(basePath + resolvedPath);
     }
     const rootWithSep = canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/';
     if (!(canonicalResolved === canonicalRoot || canonicalResolved.startsWith(rootWithSep))) {

--- a/src/app/api/scan-library/route.ts
+++ b/src/app/api/scan-library/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { readdir } from 'fs/promises';
-import { join } from 'path';
+import { readdir, realpath } from 'fs/promises';
+import { join, resolve } from 'path';
 import { homedir } from 'os';
 import type { Dirent } from 'fs';
 import { titleFromPath } from '@/lib/titleFromPath';
@@ -65,11 +65,30 @@ export async function GET(request: NextRequest) {
   }
 
   const resolvedPath = resolveFolderPath(pathParam);
+  const home = homedir();
+  let validatedBasePath: string;
+  try {
+    const canonicalRoot = await realpath(home);
+    const canonicalResolved = await realpath(resolve(home, resolvedPath));
+    if (!canonicalResolved.startsWith(canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/')) {
+      return NextResponse.json(
+        { error: 'Requested path is outside of the allowed directory.' },
+        { status: 403 }
+      );
+    }
+    validatedBasePath = canonicalResolved;
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid or inaccessible path.' },
+      { status: 400 }
+    );
+  }
+
   const forceRefresh = request.nextUrl.searchParams.get('refresh') === '1' || request.nextUrl.searchParams.get('refresh') === 'true';
 
   try {
   if (!forceRefresh) {
-    const cached = scanCache.get(resolvedPath);
+    const cached = scanCache.get(validatedBasePath);
     const hasPathMap = cached?.pathByItemId && Object.keys(cached.pathByItemId).length > 0;
     if (cached && Date.now() - cached.cachedAt < CACHE_TTL_MS && hasPathMap) {
       itemIdToPath.clear();
@@ -153,7 +172,7 @@ export async function GET(request: NextRequest) {
   // 1) Subfolders: each folder that contains at least one video = one movie (pick one video per folder)
   const subdirs = entries.filter((e) => e.isDirectory());
   for (const dir of subdirs) {
-    const folderPath = join(resolvedPath, dir.name);
+    const folderPath = join(validatedBasePath, dir.name);
     let subEntries: Dirent[];
     try {
       subEntries = await readdir(folderPath, { withFileTypes: true });

--- a/src/app/api/scan-library/route.ts
+++ b/src/app/api/scan-library/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readdir, realpath } from 'fs/promises';
-import { join, resolve } from 'path';
+import { join, resolve, isAbsolute } from 'path';
 import { homedir } from 'os';
 import type { Dirent } from 'fs';
 import { titleFromPath } from '@/lib/titleFromPath';
@@ -69,8 +69,14 @@ export async function GET(request: NextRequest) {
   let validatedBasePath: string;
   try {
     const canonicalRoot = await realpath(home);
-    const canonicalResolved = await realpath(resolve(home, resolvedPath));
-    if (!canonicalResolved.startsWith(canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/')) {
+    let canonicalResolved: string;
+    if (isAbsolute(resolvedPath)) {
+      canonicalResolved = await realpath(resolvedPath);
+    } else {
+      canonicalResolved = await realpath(resolve(canonicalRoot, resolvedPath));
+    }
+    const rootWithSep = canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/';
+    if (!(canonicalResolved === canonicalRoot || canonicalResolved.startsWith(rootWithSep))) {
       return NextResponse.json(
         { error: 'Requested path is outside of the allowed directory.' },
         { status: 403 }

--- a/src/app/api/scan-library/route.ts
+++ b/src/app/api/scan-library/route.ts
@@ -73,8 +73,7 @@ export async function GET(request: NextRequest) {
     if (isAbsolute(resolvedPath)) {
       canonicalResolved = await realpath(resolvedPath);
     } else {
-      const basePath = canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/';
-      canonicalResolved = await realpath(basePath + resolvedPath);
+      canonicalResolved = await realpath(resolve(canonicalRoot, resolvedPath));
     }
     const rootWithSep = canonicalRoot.endsWith('/') ? canonicalRoot : canonicalRoot + '/';
     if (!(canonicalResolved === canonicalRoot || canonicalResolved.startsWith(rootWithSep))) {


### PR DESCRIPTION
Potential fix for [https://github.com/sotiriskar/nyetflix/security/code-scanning/2](https://github.com/sotiriskar/nyetflix/security/code-scanning/2)

In general, to fix this kind of issue you must constrain user-controlled paths before using them with filesystem APIs. A common and flexible approach is to define a root directory (or a small allow-list of root directories), resolve the user-specified path relative to that root, normalize it (removing `..` segments, resolving symlinks), and then verify that the resulting absolute path is still within the root. Only then should you pass it to `readdir` or other filesystem functions.

For this specific code, the minimal change that preserves existing behavior is:

1. Introduce a secure “base library root” under which all scanning must occur. A natural choice, consistent with the existing `resolveFolderPath` logic, is the user’s home directory returned by `homedir()`. This allows `/Documents`, `~/Movies`, etc., but prevents scanning outside the home directory (such as `/etc`).
2. After `resolveFolderPath(pathParam)` returns `resolvedPath`, construct an absolute, normalized path using `path.resolve` with the home directory as the base, and then use `fs.realpathSync` (or `fs.promises.realpath`) to resolve symlinks.
3. Verify that the canonical path starts with the intended root (the home directory path, normalized in the same way). If it does not, return an HTTP 400/403 error instead of proceeding.
4. Use this validated path for all subsequent filesystem operations in the handler (`readdir`, `join`, etc.).

Because we must not change imports except to add standard ones, and we already have `join` from `path`, we can extend the `path` import to include `resolve` or alternatively import the whole module. We also need `realpath` from `fs/promises` or `realpathSync` from `fs`; since we already use async/await with `readdir` from `fs/promises`, adding `realpath` from `fs/promises` is consistent and avoids sync IO.

Concretely, in `src/app/api/scan-library/route.ts`:

- Update the imports to also bring in `realpath` from `fs/promises` and `resolve` from `path`.
- Inside `GET`, right after computing `resolvedPath`, compute `const home = homedir(); const canonicalRoot = await realpath(home); const canonicalResolved = await realpath(resolve(home, resolvedPath));` and then check `canonicalResolved.startsWith(canonicalRoot + pathSep)` (or equivalent logic to avoid partial-prefix issues). If the check fails, return 400/403.
- Replace further uses of `resolvedPath` when accessing the filesystem with `canonicalResolved` so that the entire traversal uses the validated path.

This adds a robust containment check while keeping the external API (`path` query parameter) and the rest of the logic unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
