### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/sotiriskar/nyetflix/security/code-scanning/3](https://github.com/sotiriskar/nyetflix/security/code-scanning/3)

In general, the fix is to explicitly declare a minimal `permissions` block in the workflow so that the GITHUB_TOKEN has only the access it needs. For a simple CI job that just checks out code and runs Node-based commands, read-only access to repository contents is sufficient, so `permissions: contents: read` is appropriate.

The best way to fix this without changing existing functionality is to add a top-level `permissions` block right after the `name` or `on` section in `.github/workflows/ci.yml`. This will apply to all jobs in the workflow (currently only `test`) and ensure the token is restricted to read-only contents. No existing steps or behavior need to be modified, and no additional scopes (like `pull-requests: write` or `checks: write`) appear to be required from the given snippet.

Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

at the root level (same indentation as `name` and `on`). No imports or external definitions are involved for YAML workflows, so no additional methods or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
